### PR TITLE
Add support for base inputs

### DIFF
--- a/action.js
+++ b/action.js
@@ -11,9 +11,11 @@ const { downloadBaseArtifact } = require("./index");
 		const artifact = core.getInput("artifact", { required: true });
 		const path = core.getInput("path", { required: false });
 		required = core.getInput("required", { required: false }) === "true";
+		const baseRef = core.getInput("baseRef", { required: false });
+		const baseSha = core.getInput("baseSha", { required: false });
 
 		const octokit = github.getOctokit(token);
-		const inputs = { workflow, artifact, path };
+		const inputs = { workflow, artifact, path, baseRef, baseSha };
 
 		core.debug("Required: " + required);
 		core.debug("Inputs: " + JSON.stringify(inputs, null, 2));

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
     description: "If required, this action will fail if a matching artifact cannot be found"
     required: false
     default: true
+  baseRef:
+    description: "The git ref that contains the base commit whose artifact is to be downloaded"
+    required: false
+  baseSha:
+    description: "The git commit SHA whose artifact for the given workflow should be downloaded"
+    required: false
 runs:
   using: "node12"
   main: "dist/action.js"

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ const defaultLogger = {
 /**
  * @typedef {ReturnType<typeof import('@actions/github').getOctokit>} GitHubActionClient
  * @typedef {typeof import('@actions/github').context} GitHubActionContext
- * @typedef {{ workflow?: string; artifact: string; path?: string; }} Inputs
+ * @typedef {{ workflow?: string; artifact: string; path?: string; baseRef?: string; baseSha?: string; }} Inputs
  * @typedef {{ warn(msg: string): void; info(msg: string): void; debug(getMsg: () => string): void; }} Logger
  *
  * @param {GitHubActionClient} octokit
@@ -160,6 +160,19 @@ async function downloadBaseArtifact(
 	log = defaultLogger
 ) {
 	const repo = context.repo;
+
+	// 0. Validate inputs
+	if (inputs.baseRef && !inputs.baseSha) {
+		throw new Error(
+			`baseRef and baseSha inputs must both be provided. Only received baseRef.`
+		);
+	}
+
+	if (!inputs.baseRef && inputs.baseSha) {
+		throw new Error(
+			`baseRef and baseSha inputs must both be provided. Only received baseRef.`
+		);
+	}
 
 	// 1. Determine workflow
 	/** @type {import('./global').WorkflowData} */
@@ -177,7 +190,13 @@ async function downloadBaseArtifact(
 
 	// 2. Determine base commit
 	let baseCommit, baseRef;
-	if (context.eventName == "push") {
+	if (inputs.baseRef && inputs.baseSha) {
+		baseCommit = inputs.baseSha;
+		baseRef = inputs.baseRef;
+
+		log.info(`Using inputs.baseRef: ${inputs.baseRef}`);
+		log.info(`Using inputs.baseSha: ${inputs.baseSha}`);
+	} else if (context.eventName == "push") {
 		baseCommit = context.payload.before;
 		baseRef = context.payload.ref;
 


### PR DESCRIPTION
Add support for specifying the base commit SHA and base ref as inputs. Specifying these inputs means the action will then find the last known good workflow run on that ref and download the requested artifact.