### PR TITLE
Conslidate baseSha and baseRef inputs into a single baseRef input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,14 +34,21 @@ jobs:
       - name: Download Base Artifact
         uses: ./
         with:
+          artifact: "test-artifact.txt"
+          path: base
+          required: ${{ !inputs.regenerate }}
+      - name: Download not-required non-existent artifact
+        uses: ./
+        with:
           artifact: "non-existent-artifact.txt"
           path: base2
           required: false
-      - name: Download Base Artifact
+      - name: Download artifact from baseRef input
         uses: ./
         with:
           artifact: "test-artifact.txt"
-          path: base
+          path: base3
+          baseRef: main
           required: ${{ !inputs.regenerate }}
       - run: ls -al
       - run: ls -al base

--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 
 For pull requests, this action looks at the branch the pull request is open against, finds the last successful workflow run for that branch, and downloads the artifact for that workflow run. For pushes, this action looks as the commit id for the branch before the push happened, finds a successful workflow run for that commit (falls back to the last successful for the branch if that commit broke the build), and downloads the artifact for that workflow run.
 
-
 ## Usage
 
 This action could be used to:
 
-* Download size metadata about the previous build and compare it against sizes for the current build
-* Download the build output of a previous build to benchmark against the output of the current build
-* Other things I haven't thought of!
+- Download size metadata about the previous build and compare it against sizes for the current build
+- Download the build output of a previous build to benchmark against the output of the current build
+- Other things I haven't thought of!
 
 ```yaml
 name: Compare artifacts
@@ -43,14 +42,22 @@ jobs:
 
 The name of the artifact to download. Required.
 
-### github_token
-
-The GITHUB_TOKEN for the current workflow run (optional)
-
-### workflow
+### workflow (optional)
 
 The workflow file name that generates the desired artifact. Defaults to the current workflow.
 
-### path
+### path (optional)
 
 The path to download the artifact to. Defaults to the current working directory.
+
+### required (optional)
+
+If required, this action will fail if a matching artifact cannot be found. Defaults to false.
+
+### baseRef (optional)
+
+Usually not required as it can be automatically determined for pull request and push events. Defaults to previous commit otherwise. But in case you want to support custom inputs, this is the git ref whose artifact is to be downloaded. For branches prefix branch name with 'heads/'. For tags prefix tag with 'tags/'. Also accepts commit shas.
+
+### github_token (optional)
+
+The GITHUB_TOKEN for the current workflow run

--- a/action.js
+++ b/action.js
@@ -13,10 +13,9 @@ import { downloadBaseArtifact } from "./index.js";
 		required =
 			core.getInput("required", { required: false })?.toLowerCase() === "true";
 		const baseRef = core.getInput("baseRef", { required: false });
-		const baseSha = core.getInput("baseSha", { required: false });
 
 		const octokit = github.getOctokit(token);
-		const inputs = { workflow, artifact, path, baseRef, baseSha };
+		const inputs = { workflow, artifact, path, baseRef };
 
 		core.debug("Required: " + required);
 		core.debug("Inputs: " + JSON.stringify(inputs, null, 2));

--- a/action.yml
+++ b/action.yml
@@ -5,16 +5,12 @@ branding:
   icon: download
   color: yellow
 inputs:
-  github_token:
-    description: "The GITHUB_TOKEN for the current workflow run"
-    required: false
-    default: ${{github.token}}
-  workflow:
-    description: "The workflow file name that generates the desired artifact. Defaults to the current workflow."
-    required: false
   artifact:
     description: "The name of the artifact to download"
     required: true
+  workflow:
+    description: "The workflow file name that generates the desired artifact. Defaults to the current workflow."
+    required: false
   path:
     description: "The path to download the artifact to. Defaults to the current working directory."
     required: false
@@ -24,6 +20,10 @@ inputs:
   baseRef:
     description: "The git ref whose artifact is to be downloaded. For branches prefix branch name with 'heads/'. For tags prefix tag with 'tags/'. Also accepts commit shas. Automatically determined for pull requests and push events."
     required: false
+  github_token:
+    description: "The GITHUB_TOKEN for the current workflow run"
+    required: false
+    default: ${{github.token}}
 runs:
   using: "node20"
   main: "dist/action.js"

--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,7 @@ inputs:
     description: "If required, this action will fail if a matching artifact cannot be found"
     required: false
   baseRef:
-    description: "The git ref that contains the base commit whose artifact is to be downloaded"
-    required: false
-  baseSha:
-    description: "The git commit SHA whose artifact for the given workflow should be downloaded"
+    description: "The git ref that contains the base commit whose artifact is to be downloaded. The HEAD of the branch will be used if baseSha is not provided."
     required: false
 runs:
   using: "node20"

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: "If required, this action will fail if a matching artifact cannot be found"
     required: false
   baseRef:
-    description: "The git ref that contains the base commit whose artifact is to be downloaded. The HEAD of the branch will be used if baseSha is not provided."
+    description: "The git ref whose artifact is to be downloaded. For branches prefix branch name with 'heads/'. For tags prefix tag with 'tags/'. Also accepts commit shas. Automatically determined for pull requests and push events."
     required: false
 runs:
   using: "node20"

--- a/dist/action.js
+++ b/dist/action.js
@@ -31559,23 +31559,25 @@ async function getGitRef(client, repo, ref, logger) {
 		} else {
 			return [sha, ref.replace(/^heads\//, "")];
 		}
-	} catch (e) {
-		logger.info(`Unable to resolve ref as-is: "${ref}"`);
-	}
+	} catch (e) {}
 
 	// Try again prefixing with "heads/" for branch name
+	const branchRef = `heads/${ref}`;
+	logger.info(
+		`Unable to resolve ref as-is: "${ref}". Trying as branch ref "${branchRef}"...`,
+	);
 	try {
 		const sha = await client.rest.git
-			.getRef({ ...repo, ref: `heads/${ref}` })
+			.getRef({ ...repo, ref: branchRef })
 			.then((r) => r.data.object.sha);
 
 		// Successfully resolved ref to sha. Return it.
 		return [sha, ref];
-	} catch (e) {
-		logger.info(`Unable to resolve ref as branch: "heads/${ref}"`);
-	}
+	} catch (e) {}
 
 	// Try again prefixing with "tags/" for tag name
+	const tagRef = `tags/${ref}`;
+	logger.info(`Unable to resolve ref as branch. Trying as tag "${tagRef}"...`);
 	try {
 		const sha = await client.rest.git
 			.getRef({ ...repo, ref: `tags/${ref}` })
@@ -31583,23 +31585,23 @@ async function getGitRef(client, repo, ref, logger) {
 
 		// Successfully resolved ref to sha. Return it.
 		return [sha, undefined];
-	} catch (e) {
-		logger.info(`Unable to resolve ref as tag: "tags/${ref}"`);
-	}
+	} catch (e) {}
 
 	// Try resolving ref as a commit
+	const commitRef = ref;
+	logger.info(`Unable to resolve ref as tag. Trying as commit sha...`);
 	try {
 		const sha = await client.rest.git
 			.getCommit({
 				...repo,
-				commit_sha: ref,
+				commit_sha: commitRef,
 			})
 			.then((r) => r.data.sha);
 
 		// Successfully resolve ref as a commit sha. Return it.
 		return [sha, undefined];
 	} catch {
-		logger.info(`Unable to resolve ref as commit sha: "${ref}"`);
+		logger.info(`Unable to resolve ref as commit sha."`);
 	}
 
 	logger.warn(

--- a/dist/action.js
+++ b/dist/action.js
@@ -31544,43 +31544,67 @@ var AdmZip = /*@__PURE__*/getDefaultExportFromCjs(admZip);
  * @param {GitHubActionClient} client
  * @param {GitHubRepo} repo
  * @param {string} ref
+ * @param {Logger} logger
  * @returns {Promise<[string | undefined, string | undefined]>}
  */
-async function getGitRef(client, repo, ref) {
-	/** @type {string | undefined} */
-	let finalRef = ref;
-	/** @type {string | undefined} */
-	let finalSha;
-
+async function getGitRef(client, repo, ref, logger) {
 	try {
-		finalSha = await client.rest.git
-			.getRef({
-				...repo,
-				ref: `heads/${ref}`,
-			})
+		const sha = await client.rest.git
+			.getRef({ ...repo, ref })
 			.then((r) => r.data.object.sha);
+
+		// Successfully resolved ref to sha. Return it.
+		if (ref.startsWith("tags/")) {
+			return [sha, undefined];
+		} else {
+			return [sha, ref.replace(/^heads\//, "")];
+		}
 	} catch (e) {
-		finalRef = undefined;
+		logger.info(`Unable to resolve ref as-is: "${ref}"`);
 	}
 
-	// Successfully resolved ref to sha. Return it.
-	if (finalSha) {
-		return [finalSha, finalRef];
+	// Try again prefixing with "heads/" for branch name
+	try {
+		const sha = await client.rest.git
+			.getRef({ ...repo, ref: `heads/${ref}` })
+			.then((r) => r.data.object.sha);
+
+		// Successfully resolved ref to sha. Return it.
+		return [sha, ref];
+	} catch (e) {
+		logger.info(`Unable to resolve ref as branch: "heads/${ref}"`);
+	}
+
+	// Try again prefixing with "tags/" for tag name
+	try {
+		const sha = await client.rest.git
+			.getRef({ ...repo, ref: `tags/${ref}` })
+			.then((r) => r.data.object.sha);
+
+		// Successfully resolved ref to sha. Return it.
+		return [sha, undefined];
+	} catch (e) {
+		logger.info(`Unable to resolve ref as tag: "tags/${ref}"`);
 	}
 
 	// Try resolving ref as a commit
 	try {
-		await client.rest.git.getCommit({
-			...repo,
-			commit_sha: ref,
-		});
+		const sha = await client.rest.git
+			.getCommit({
+				...repo,
+				commit_sha: ref,
+			})
+			.then((r) => r.data.sha);
 
 		// Successfully resolve ref as a commit sha. Return it.
-		return [ref, undefined];
+		return [sha, undefined];
 	} catch {
-		// Do nothing
+		logger.info(`Unable to resolve ref as commit sha: "${ref}"`);
 	}
 
+	logger.warn(
+		`Unable to resolve ref. See above logs for attempted resolutions.`,
+	);
 	return [undefined, undefined];
 }
 
@@ -31771,7 +31795,7 @@ async function downloadBaseArtifact(
 	let baseRef;
 
 	if (inputs.baseRef) {
-		const [commit, ref] = await getGitRef(octokit, repo, inputs.baseRef);
+		const [commit, ref] = await getGitRef(octokit, repo, inputs.baseRef, log);
 
 		if (!commit) {
 			throw new Error(

--- a/index.js
+++ b/index.js
@@ -8,6 +8,50 @@ import AdmZip from "adm-zip";
 /**
  * @param {GitHubActionClient} client
  * @param {GitHubRepo} repo
+ * @param {string} ref
+ * @returns {Promise<[string | undefined, string | undefined]>}
+ */
+export async function getGitRef(client, repo, ref) {
+	/** @type {string | undefined} */
+	let finalRef = ref;
+	/** @type {string | undefined} */
+	let finalSha;
+
+	try {
+		finalSha = await client.rest.git
+			.getRef({
+				...repo,
+				ref: `heads/${ref}`,
+			})
+			.then((r) => r.data.object.sha);
+	} catch (e) {
+		finalRef = undefined;
+	}
+
+	// Successfully resolved ref to sha. Return it.
+	if (finalSha) {
+		return [finalSha, finalRef];
+	}
+
+	// Try resolving ref as a commit
+	try {
+		await client.rest.git.getCommit({
+			...repo,
+			commit_sha: ref,
+		});
+
+		// Successfully resolve ref as a commit sha. Return it.
+		return [ref, undefined];
+	} catch {
+		// Do nothing
+	}
+
+	return [undefined, undefined];
+}
+
+/**
+ * @param {GitHubActionClient} client
+ * @param {GitHubRepo} repo
  * @param {number} run_id
  * @returns {Promise<WorkflowData>}
  */
@@ -154,7 +198,7 @@ const defaultLogger = {
 /**
  * @typedef {ReturnType<typeof import('@actions/github').getOctokit>} GitHubActionClient
  * @typedef {typeof import('@actions/github').context} GitHubActionContext
- * @typedef {{ workflow?: string; artifact: string; path?: string; baseRef?: string; baseSha?: string; }} Inputs
+ * @typedef {{ workflow?: string; artifact: string; path?: string; baseRef?: string; }} Inputs
  * @typedef {{ warn(msg: string): void; info(msg: string): void; debug(getMsg: () => string): void; }} Logger
  * @typedef {GitHubActionContext["payload"]["pull_request"]} PRPayload
  *
@@ -170,19 +214,6 @@ export async function downloadBaseArtifact(
 	log = defaultLogger,
 ) {
 	const repo = context.repo;
-
-	// 0. Validate inputs
-	if (inputs.baseRef && !inputs.baseSha) {
-		throw new Error(
-			`baseRef and baseSha inputs must both be provided. Only received baseRef.`,
-		);
-	}
-
-	if (!inputs.baseRef && inputs.baseSha) {
-		throw new Error(
-			`baseRef and baseSha inputs must both be provided. Only received baseRef.`,
-		);
-	}
 
 	// 1. Determine workflow
 	/** @type {WorkflowData} */
@@ -201,14 +232,26 @@ export async function downloadBaseArtifact(
 	// 2. Determine base commit
 	/** @type {string} */
 	let baseCommit;
-	/** @type {string} */
+	/** @type {string | undefined} */
 	let baseRef;
-	if (inputs.baseRef && inputs.baseSha) {
-		baseCommit = inputs.baseSha;
-		baseRef = inputs.baseRef;
 
-		log.info(`Using inputs.baseRef: ${inputs.baseRef}`);
-		log.info(`Using inputs.baseSha: ${inputs.baseSha}`);
+	if (inputs.baseRef) {
+		const [commit, ref] = await getGitRef(octokit, repo, inputs.baseRef);
+
+		if (!commit) {
+			throw new Error(
+				`Unable to resolve base commit with inputs.baseRef: "${inputs.baseRef}"`,
+			);
+		}
+
+		baseCommit = commit;
+		baseRef = ref;
+
+		if (ref) {
+			log.info(`Resolved head of "${baseRef}" to commit ${baseCommit}`);
+		} else {
+			log.info(`Using base commit: ${baseCommit}`);
+		}
 	} else if (context.eventName == "push") {
 		baseCommit = context.payload.before;
 		baseRef = context.payload.ref;

--- a/index.js
+++ b/index.js
@@ -24,23 +24,25 @@ export async function getGitRef(client, repo, ref, logger) {
 		} else {
 			return [sha, ref.replace(/^heads\//, "")];
 		}
-	} catch (e) {
-		logger.info(`Unable to resolve ref as-is: "${ref}"`);
-	}
+	} catch (e) {}
 
 	// Try again prefixing with "heads/" for branch name
+	const branchRef = `heads/${ref}`;
+	logger.info(
+		`Unable to resolve ref as-is: "${ref}". Trying as branch ref "${branchRef}"...`,
+	);
 	try {
 		const sha = await client.rest.git
-			.getRef({ ...repo, ref: `heads/${ref}` })
+			.getRef({ ...repo, ref: branchRef })
 			.then((r) => r.data.object.sha);
 
 		// Successfully resolved ref to sha. Return it.
 		return [sha, ref];
-	} catch (e) {
-		logger.info(`Unable to resolve ref as branch: "heads/${ref}"`);
-	}
+	} catch (e) {}
 
 	// Try again prefixing with "tags/" for tag name
+	const tagRef = `tags/${ref}`;
+	logger.info(`Unable to resolve ref as branch. Trying as tag "${tagRef}"...`);
 	try {
 		const sha = await client.rest.git
 			.getRef({ ...repo, ref: `tags/${ref}` })
@@ -48,23 +50,23 @@ export async function getGitRef(client, repo, ref, logger) {
 
 		// Successfully resolved ref to sha. Return it.
 		return [sha, undefined];
-	} catch (e) {
-		logger.info(`Unable to resolve ref as tag: "tags/${ref}"`);
-	}
+	} catch (e) {}
 
 	// Try resolving ref as a commit
+	const commitRef = ref;
+	logger.info(`Unable to resolve ref as tag. Trying as commit sha...`);
 	try {
 		const sha = await client.rest.git
 			.getCommit({
 				...repo,
-				commit_sha: ref,
+				commit_sha: commitRef,
 			})
 			.then((r) => r.data.sha);
 
 		// Successfully resolve ref as a commit sha. Return it.
 		return [sha, undefined];
 	} catch {
-		logger.info(`Unable to resolve ref as commit sha: "${ref}"`);
+		logger.info(`Unable to resolve ref as commit sha."`);
 	}
 
 	logger.warn(

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -7,6 +7,7 @@ import {
 	getWorkflowFromRunId,
 	getWorkflowRunForCommit,
 	getArtifact,
+	getGitRef,
 } from "../index.js";
 
 // Mostly copied from: https://github.com/actions/toolkit/blob/cee7d92d1d02e3107c9b1387b9690b89096b67be/packages/github/src/utils.ts#L12
@@ -66,9 +67,11 @@ const gitRef = "refs/heads/master";
 const artifactName = "test-artifact.txt";
 const artifactId = 408992374;
 
-const prBranch = "upgrade-deps-and-node16";
-const prRunId = 3310272485;
-const prSha = "12d4e33eeeb5afb2d99cea6dfa1f6b1ad1caff17";
+const prBranch = "test-branch";
+const prSha = "62722153c751ecd3676c48fb43a42869f39ed9e2";
+const prRunId = 6703640458;
+
+const unknownSha = "9c81cadeed9dfc5a2ae8555046b323bf3be712cf";
 
 test("getWorkflowFromFile", async () => {
 	const workflow = await getWorkflowFromFile(testClient, testRepo, "main.yml");
@@ -140,7 +143,7 @@ test("getWorkflowRunForCommit with unknown commit", async () => {
 		testClient,
 		testRepo,
 		workflowId,
-		"9c81cadeed9dfc5a2ae8555046b323bf3be712cf",
+		unknownSha,
 		gitRef,
 	);
 
@@ -163,4 +166,22 @@ test("getArtifact not found", async () => {
 		/Not Found/g,
 		"Expected getArtifact to reject if artifact not found",
 	);
+});
+
+test("getGitRef with branch name", async () => {
+	const [commit, ref] = await getGitRef(testClient, testRepo, prBranch);
+	assert.equal(commit, prSha);
+	assert.equal(ref, prBranch);
+});
+
+test("getGitRef with commit sha", async () => {
+	const [commit, ref] = await getGitRef(testClient, testRepo, prSha);
+	assert.equal(commit, prSha);
+	assert.equal(ref, undefined);
+});
+
+test("getGitRef with unknown ref", async () => {
+	const [commit, ref] = await getGitRef(testClient, testRepo, unknownSha);
+	assert.equal(commit, undefined);
+	assert.equal(ref, undefined);
 });


### PR DESCRIPTION
Combine baseSha and baseRef inputs into baseRef input that accepts branch names, tag names, and commit shas.